### PR TITLE
Allow the plug-in to match users using the claims OID or appID

### DIFF
--- a/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/AADConstants.java
+++ b/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/AADConstants.java
@@ -14,5 +14,6 @@ public class AADConstants {
   public static final String DISABLE_LOGIN_FORM = "disableLoginForm"; 
   public static final String ALLOW_MATCHING_USERS_BY_EMAIL = "allowMatchingUsersByEmail";
   public static final String ENABLE_TOKEN_AUTHENTICATION = "enableTokenAuthentication";
+  public static final String ID_CLAIM_TOKEN_AUTHENTICATION = "idClaimTokenAuthentication";
   public static final PropertyKey OID_USER_PROPERTY_KEY = new PluginPropertyKey(PluginTypes.AUTH_PLUGIN_TYPE, "azure-active-directory", "oid");
 }

--- a/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/BearerTokenAuthenticator.java
+++ b/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/BearerTokenAuthenticator.java
@@ -31,6 +31,7 @@ public class BearerTokenAuthenticator extends TokenAuthenticator {
 	@Override
 	public HttpAuthenticationResult processAuthenticationRequest(@NotNull HttpServletRequest request, @NotNull HttpServletResponse response) throws IOException {
 		
+		final String claimName = schemeProperties.get(AADConstants.ID_CLAIM_TOKEN_AUTHENTICATION);
 		final String idTokenString = this.GetToken(request);
 	
 	    final JWT token = JWT.parse(idTokenString);
@@ -45,15 +46,15 @@ public class BearerTokenAuthenticator extends TokenAuthenticator {
 	      return sendUnauthorized(request, response, errorDescription);
 	    }
 	
-	    final String oid = token.getClaim(ClaimsConstants.OID_CLAIM);
+	    final String oid = token.getClaim(claimName);
 	
 	    if (oid == null)
-	      return sendBadRequest(response, "The required claim " + ClaimsConstants.OID_CLAIM + "was not found in parsed JWT");
+	      return sendBadRequest(response, "The required claim '" + claimName + "' was not found in parsed JWT");
 	
 	    final ServerPrincipal principal = myPrincipalFactory.getServerPrincipal(oid, oid, oid, schemeProperties);
 	   
 	    if(principal == null){
-			return sendUnauthorized(request, response, String.format("User with OID %s not found. (Remember to place the OID in the email field)", oid));
+			return sendUnauthorized(request, response, String.format("User with " + claimName + " %s not found. (Remember to place the '" + claimName + "' in the email field)", oid));
 	    }
 	    LOG.debug("Request authenticated. Determined user " + principal.getName());
 	    return HttpAuthenticationResult.authenticated(principal, true);

--- a/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/ClaimsConstants.java
+++ b/azure-active-directory-server/src/main/java/org/jetbrains/teamcity/aad/ClaimsConstants.java
@@ -12,6 +12,7 @@ public class ClaimsConstants {
 	public static final String NONCE_CLAIM = "nonce";
 	public static final String NAME_CLAIM = "unique_name";
 	public static final String OID_CLAIM = "oid"; //object ID
+	public static final String APPID_CLAIM = "appid";
 	public static final String EMAIL_CLAIM = "upn";
 	public static final String ERROR_CLAIM = "error";
 	public static final String ERROR_DESCRIPTION_CLAIM = "error_description";

--- a/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
+++ b/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
@@ -39,7 +39,7 @@
     	<prop:option value="<%=org.jetbrains.teamcity.aad.ClaimsConstants.OID_CLAIM%>">Object Id</prop:option>
     </prop:selectProperty>
     </br>
-    <span class="grayNote">The claim that will be used for matching the bearer token with a TeamCity user.</span>
+    <span class="grayNote">The claim that will be used for matching the bearer token with a TeamCity user's email field.</span>
 </div>
 
 <script type="text/javascript">

--- a/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
+++ b/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
@@ -38,6 +38,7 @@
     	<prop:option value="<%=org.jetbrains.teamcity.aad.ClaimsConstants.APPID_CLAIM%>">Application ID</prop:option>
     	<prop:option value="<%=org.jetbrains.teamcity.aad.ClaimsConstants.OID_CLAIM%>">Object Id</prop:option>
     </prop:selectProperty>
+    </br>
     <span class="grayNote">The claim that will be used for matching the bearer token with a TeamCity user.</span>
 </div>
 

--- a/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
+++ b/azure-active-directory-server/src/main/resources/buildServerResources/editAADSchemeProperties.jsp
@@ -31,3 +31,24 @@
     <label width="100%" for="<%=org.jetbrains.teamcity.aad.AADConstants.ENABLE_TOKEN_AUTHENTICATION%>">Enable token authentication</label><br/>
     <span class="grayNote">Enable bearer token authentication on HTTP requests for API calls</span>
 </div>
+<br/>
+<div>
+    <label width="100%" for="<%=org.jetbrains.teamcity.aad.AADConstants.ID_CLAIM_TOKEN_AUTHENTICATION%>">Claim:</label><br/>
+    <prop:selectProperty name="<%=org.jetbrains.teamcity.aad.AADConstants.ID_CLAIM_TOKEN_AUTHENTICATION%>">
+    	<prop:option value="<%=org.jetbrains.teamcity.aad.ClaimsConstants.APPID_CLAIM%>">Application ID</prop:option>
+    	<prop:option value="<%=org.jetbrains.teamcity.aad.ClaimsConstants.OID_CLAIM%>">Object Id</prop:option>
+    </prop:selectProperty>
+    <span class="grayNote">The claim that will be used for matching the bearer token with a TeamCity user.</span>
+</div>
+
+<script type="text/javascript">
+    (function(){
+    
+    	var checkbox = document.getElementsByName("prop:<%=org.jetbrains.teamcity.aad.AADConstants.ENABLE_TOKEN_AUTHENTICATION%>")[0];
+    	checkbox.onchange = function() {
+    		document.getElementsByName("prop:<%=org.jetbrains.teamcity.aad.AADConstants.ID_CLAIM_TOKEN_AUTHENTICATION%>")[0].disabled = !checkbox.checked;
+    	}
+    	checkbox.onchange();
+    	
+    })();
+</script>


### PR DESCRIPTION
I added a combo box in the plug-in settings for selecting whether to use OID or AppId for matching the token with an user.